### PR TITLE
Improve dataset building

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,42 +11,60 @@ Getting Started
 To use ciml, you have to collect a dataset and train the model. Once that's done
 you can perform predictions on new data using the MQTT triggered pipeline.
 
-To collect a dataset, use ciml-build-dataset:
+The complete workflow to create a trained model is designed to allow easy
+experimentation and tuning of data preparation as well as model parameters and
+hyper-parameters:
+
+* Cache raw data (dstat CSV files) and run metadata from OpenStack log server
+  and test result database. After this step, everything else may be done
+  offline, as only cached data will be used
+* Build a normalized dataset, split into training, dev and test. This step
+  allows to define the number of samples, the level of downsampling (in any)
+  and which dstat columns we want to use
+* Define an experiment. Experiments are defined by a model with its
+  parameters and hyper-parameters. Experiments are associated to datasets.
+  Each dataset can have multiple experiments
+* Train a model i.e. run an experiment against a dataset
+
+
+To cache raw data locally, use `ciml-cache-data`:
 
 .. code:: shell
 
-  ciml-build-dataset --dataset <dataset-name> --build-name <build_name>
+  ciml-cache-data --build-name <build-name> --db-uri <db-uri>
 
 This connects to the OpenStack subunit2sql database, fetch all runs that
 match the specified build_name and try to download the dstat data from
 logs.openstack.org. The dstat file and build results are stored gzipped
-under data/<dataset-name>/raw.
+under data/.raw and data/.metadata.
 
-Running ciml-build-dataset with the same dataset again extends the dataset if
-new results are found.
+Running ciml-cache-data with the same build name again extends the cache.
+Data for different build names can be cached, dedicated json files keep track
+of which data belongs to which build.
 
-Full more help run:
+For more help run:
+
+.. code:: shell
+
+  ciml-cache-data --help
+
+To create a normalized dataset, use `ciml-build-dataset`:
+
+.. code:: shell
+
+  ciml-build-dataset --dataset <dataset-name> --build-name <build-name>
+
+This selects the required number of runs from the local cache, it loads the
+data into memory, it runs the normalization step and it saves the three
+resulting datasets (traning, dev and test) into numpy compressed archives
+(.npz) files. It also creates one compressed archieve for the feature labels.
+
+There are several extra options that can be used to control size and
+normalization of the resulting dataset. For more help run:
 
 .. code:: shell
 
   ciml-build-dataset --help
-
-
-To train the model, ciml-build-dataset:
-
-.. code:: shell
-
-  ciml-train-model --dataset <dataset-name>
-
-This looks in the raw data folder and loads the list of runs (examples) from
-there along with the test results (classes: pass or failed).
-Data is normalised and then passed to the trainer for train the model.
-
-Full more help run:
-
-.. code:: shell
-
-  ciml-train-model --help
 
 It is also possible to visualize the lenght of example prior to normalization,
 and how it maps to the example class (0 for passed, 1 for failed).
@@ -54,10 +72,42 @@ To produce the graph, run:
 
 .. code:: shell
 
-  ciml-train-model --dataset <dataset-name> --no-train --visualize
+    ciml-build-dataset --dataset <dataset-name> --visualize
 
 .. image:: sizes_by_result.png
 
+To define an experiment, use `ciml-setup-experiment`:
+
+.. code:: shell
+
+  ciml-setup-experiment --dataset <dataset-name> --experiment <exp-name> \
+    --estimator (tf.contrib.learn.SVM|tf.estimator.DNNClassifier)
+
+This stores the specified model, parameter and hyper-parameters into a json
+file in a dedicated folder, which is going to host TensorFlow model files as
+well.
+
+Full more help run:
+
+.. code:: shell
+
+  ciml-setup-experiment --help
+
+To run training, use `ciml-train-model`:
+
+.. code:: shell
+
+  ciml-train-model --dataset <dataset-name> --experiment <exp-name>
+
+This loads the dataset from the numpy compressed archieves, it initialize the
+model based on the experiment settings and runs training against the training
+set and evaluation against the test set.
+
+To use TensorBoard for a specific experiment, run:
+
+.. code:: shell
+
+  tensorboard --logdir <ciml_base_path>/data/<dataset-name>/<experiment-name>
 
 To start the MQTT triggered pipeline, and make predictions on new data, use:
 

--- a/ciml/svm_trainer.py
+++ b/ciml/svm_trainer.py
@@ -40,13 +40,18 @@ class SVMTrainer(object):
             model_data_folder = os.sep.join([model_path, 'data', dataset_name,
                                              'model'])
         os.makedirs(model_data_folder, exist_ok=True)
+        my_checkpointing_config = tf.estimator.RunConfig(
+            save_checkpoints_secs = 10,  # Save checkpoints every 20 minutes.
+            keep_checkpoint_max = 100,       # Retain the 10 most recent checkpoints.
+        )
         self.estimator = tf.contrib.learn.SVM(
             feature_columns=self.feature_columns,
             example_id_column='example_id',
             model_dir=model_data_folder,
-            feature_engineering_fn=self.feature_engineering_fn)
+            feature_engineering_fn=self.feature_engineering_fn,
+            config=my_checkpointing_config)
 
-        # Separate traing set and evaluation set by building randomised lists
+        # Separate training set and evaluation set by building randomised lists
         # of indexes that can be used for examples, example_ids and classes
         self.all_indexes = range(len(self.example_ids))
         self.training_idx = pd.Series(self.all_indexes).sample(

--- a/ciml/svm_trainer.py
+++ b/ciml/svm_trainer.py
@@ -49,7 +49,7 @@ class SVMTrainer(object):
             model_dir=model_data_folder,
             config=my_checkpointing_config)
 
-    def input_fn(self, examples, example_ids, classes, return_classes=True):
+    def input_fn(self, examples, example_ids, classes):
         num_features = len(self.feature_columns)
         # Dict comprehension to build a dict of features
         # I suppose numpy might be able to do this more efficiently
@@ -59,10 +59,7 @@ class SVMTrainer(object):
             for n in range(num_features)}
         _features['example_id'] = tf.constant(example_ids)
         print("Done preparing input data")
-        if return_classes:
-            return _features, tf.constant(classes)
-        else:
-            return _features
+        return _features, tf.constant(classes)
 
     def training_input_fn(self):
         return self.input_fn(**self.training_data)
@@ -82,10 +79,3 @@ class SVMTrainer(object):
             train_loss = self.estimator.evaluate(
                 input_fn=self.evaluate_input_fn, steps=1)
         print('Training loss %r' % train_loss)
-
-    def predict_fn(self):
-        return self.input_fn(return_classes=False, **self.training_data)
-
-    def predict(self):
-        prediction = list(self.estimator.predict(input_fn=self.predict_fn))
-        return prediction

--- a/ciml/tf_trainer.py
+++ b/ciml/tf_trainer.py
@@ -1,0 +1,68 @@
+# Copyright 2018 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+
+tf.logging.set_verbosity(tf.logging.INFO)
+
+
+def get_feature_columns(labels):
+    return [tf.contrib.layers.real_valued_column(x) for x in labels]
+
+
+def input_fn(examples, example_ids, classes, labels):
+    feature_columns = get_feature_columns(labels)
+    num_features = len(labels)
+    # Dict comprehension to build a dict of features
+    # I suppose numpy might be able to do this more efficiently
+    _features = {
+        labels[n]: tf.constant(examples[:,n]) for n in range(num_features)}
+    # _features['example_id'] = tf.constant(example_ids)
+    return _features, tf.constant(classes)
+
+
+def get_checkpoint_config():
+    return tf.estimator.RunConfig(
+        save_checkpoints_secs = 10,  # Save checkpoints every 10s.
+        keep_checkpoint_max = 100,   # Retain the 100 most recent checkpoints.
+    )
+
+def get_estimator(estimator_name, hyper_params, params, labels, model_dir):
+
+    # SVM Model
+    if estimator_name == 'tf.contrib.learn.SVM':
+        return tf.contrib.learn.SVM(
+            feature_columns=get_feature_columns(labels),
+            example_id_column='example_id',
+            model_dir=model_dir,
+            config=get_checkpoint_config())
+
+    # DNN Model
+    if estimator_name == 'tf.estimator.DNNClassifier':
+        return tf.estimator.DNNClassifier(
+            feature_columns=get_feature_columns(labels),
+            model_dir=model_dir,
+            config=get_checkpoint_config(),
+            hidden_units=hyper_params['hidden_units'],
+            n_classes=2)
+
+def get_training_method(estimator):
+    if type(estimator).__name__ == 'SVM':
+        return getattr(estimator, 'fit')
+    else:
+        return getattr(estimator, 'train')

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ console_scripts =
     ciml-db-batch-predict = ciml.predict:db_batch_predict
     ciml-mqtt-predict = ciml.predict:mqtt_predict
     ciml-mqtt-trainer = ciml.trainer:mqtt_trainer
-    ciml-build-dataset = ciml.trainer:dataset_build
+    ciml-cache-data = ciml.gather_results:cache_data
+    ciml-build-dataset = ciml.trainer:build_dataset
     ciml-train-model = ciml.trainer:local_trainer
     ciml-train-api-server = ciml.train_api:main
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ console_scripts =
     ciml-db-batch-predict = ciml.predict:db_batch_predict
     ciml-mqtt-predict = ciml.predict:mqtt_predict
     ciml-mqtt-trainer = ciml.trainer:mqtt_trainer
-    ciml-build-dataset = ciml.trainer:db_trainer
+    ciml-build-dataset = ciml.trainer:dataset_build
     ciml-train-model = ciml.trainer:local_trainer
     ciml-train-api-server = ciml.train_api:main
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ console_scripts =
     ciml-mqtt-trainer = ciml.trainer:mqtt_trainer
     ciml-cache-data = ciml.gather_results:cache_data
     ciml-build-dataset = ciml.trainer:build_dataset
+    ciml-setup-experiment = ciml.trainer:setup_experiment
     ciml-train-model = ciml.trainer:local_trainer
     ciml-train-api-server = ciml.train_api:main
 


### PR DESCRIPTION
We only use the db_trainer for dataset building, so renaming it,
and changing it to use a new gather_data module function that loops
through runs re-using a single DB session.

Store on disk under .unavailable the ID of runs for which no dstat
data is available to download (nor cached), so that we don't check
them everytime using an expensive HTTP call.

Handle CSV parsing issues, delete a cache file when they come from
a local cache, since this usally means that the local cache is
corrupt).