### PR TITLE
Support s3 storage for raw data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ tensorflow>=1.6.0 # Apache-2.0
 PyMySQL>=0.8.0
 click
 flask>=0.12.2
+# boto to support s3 based storage
+boto3


### PR DESCRIPTION
Allow storing/caching raw data (logs + metadata) on any object
storage with an s3 compatible API in front.

This is useful to move the analysis part of the ML work to the
cloud and to keep growing the dataset on a regular basis.