### PR TITLE
Switch to tensorflow 1.6.0 (non gpu)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ subunit2sql>=1.9.0 # Apache-2.0
 SQLAlchemy>=1.3.0 # MIT
 matplotlib>=2.1.2
 pandas>=0.20.1
-tensorflow-gpu>=1.6.0 # Apache-2.0
+tensorflow>=1.6.0 # Apache-2.0
 PyMySQL>=0.8.0
 click
 flask>=0.12.2


### PR DESCRIPTION
We don't really use TF GPU capabilities today, so switch to tf 1.6.0
for now since tensorflow-gpu 1.6.0 does not seem to exists.