### PR TITLE
Remove quotes around the tdt param

### DIFF
--- a/tekton/create_dataset.yaml
+++ b/tekton/create_dataset.yaml
@@ -86,7 +86,7 @@ spec:
         --sample-interval "$(inputs.params.sample-interval)" \
         --features-regex "$(inputs.params.features-regex)" \
         --class-label "$(inputs.params.class-label)" \
-        --tdt-split "$(inputs.params.tdt-split)" \
+        --tdt-split $(inputs.params.tdt-split) \
         --data-path "$(inputs.params.data-path)" \
         --target-data-path "$(inputs.params.target-data-path)" \
         $EXTRA_PARAMS


### PR DESCRIPTION
Remove quotes around the tdt param so that is parsed as a list of
integers and not a string.