### PR TITLE
Add scripts and tasks to run from a Tekton task

### DIFF
--- a/ciml/trainer.py
+++ b/ciml/trainer.py
@@ -771,7 +771,7 @@ def local_trainer(dataset, experiment, eval_dataset, gpu, debug, data_path,
     if class_label == 'node_provider':
         label_vocabulary = set(['rax', 'ovh', 'packethost-us-west-1',
                                 'vexxhost', 'limestone-regionone',
-                                'inap-mtl01'])
+                                'inap-mtl01', 'fortnebula-regionone'])
     elif class_label == 'node_provider_all':
         label_vocabulary = set(['rax-iad', 'ovh-bhs1', 'packethost-us-west-1',
                                 'rax-dfw', 'vexxhost-ca-ymq-1', 'ovh-gra1',

--- a/images/tkn/Dockerfile
+++ b/images/tkn/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.10
+LABEL maintainer "Andrea Frittoli <andrea.frittoli@gmail.com>"
+
+RUN apk update; apk upgrade; apk add bash util-linux
+
+ARG KUBECTL_VERSION=1.16.0
+RUN wget -O/usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl; chmod +x /usr/local/bin/kubectl
+
+ARG TKN_VERSION=0.5.0
+RUN wget -O- https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz | tar zxf - -C /usr/local/bin

--- a/scripts/run_with_tekton.sh
+++ b/scripts/run_with_tekton.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -e
+
+GIT_RESOURCE=${GIT_RESOURCE:-ciml-master}
+EXPERIMENTS_BUCKET_RESOURCE=${EXPERIMENTS_BUCKET_RESOURCE:-cimlexperiments}
+MAX_CONCURRENCY=${MAX_CONCURRENCY:-20}
+DATASETS=${DATASETS:-datasets}
+EXPERIMENTS=${EXPERIMENTS:-experiments}
+DATA_BUCKET=${DATA_BUCKET:-cimlodsceu2019}
+OUTPUT_BUCKET=${OUTPUT_BUCKET:-cimlodsceu2019output}
+TRAINING_LOG=${TRAINING_LOG:-training_log.csv}
+
+function _running_tasks() {
+  kubectl get tr -l "ciml/run.uuid: $RUN_UUID"  2> /dev/null || echo "STATUS" | egrep -v '(STATUS|Succeeded|Failed)' | wc -l
+}
+
+function _wait_for_slot(){
+  running=$(_running_tasks)
+  while [[ $running -ge $MAX_CONCURRENCY ]]; do
+    echo "Waiting: $running tasks"
+    sleep 5
+    running=$(_running_tasks)
+  done
+}
+
+function _create_bucket_resource() {
+  BUCKET=$1
+  BPATH=$2
+  BNAME=bucket-$(echo $BPATH | tr '_' '-')
+  cat <<EOF | kubectl apply -f - -o jsonpath='{.metadata.name}'
+  apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    name: $BNAME
+    labels:
+      ciml/run.uuid: $RUN_UUID
+  spec:
+    params:
+    - name: type
+      value: gcs
+    - name: location
+      value: s3://$BUCKET/$BPATH
+    - name: dir
+      value: "y"
+    secrets:
+    - fieldName: BOTO_CONFIG
+      secretKey: boto_config
+      secretName: cos
+    type: storage
+EOF
+}
+
+function run_trainings() {
+  for dataset in $(cat ${DATASETS}); do
+    for experiment in $(cat ${EXPERIMENTS}); do
+      echo "=== Running training $dataset / $experiment"
+      # Wait for a slot, do not overload the cluster
+      _wait_for_slot
+      # Generate UUID and create the log
+      UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+      echo "$(date +'%F %R');$dataset;$experiment;$UUID" >> $TRAINING_LOG
+      # Create Tekton resources
+      DATASET_BUCKET_RESOURCE=$(_create_bucket_resource $DATA_BUCKET $dataset)
+      OUTPUT_BUCKET_RESOURCE=$(_create_bucket_resource $OUTPUT_BUCKET $UUID)
+      # Debug the training command
+      echo tkn task start \
+        -i ciml=$GIT_RESOURCE \
+        -i experiments=$EXPERIMENTS_BUCKET_RESOURCE \
+        -i dataset=$DATASET_BUCKET_RESOURCE \
+        -o cimloutput=$OUTPUT_BUCKET_RESOURCE \
+        -p dataset=$dataset \
+        -p experiment=$experiment \
+        -s ciml-bot \
+        --showlog=false \
+        --labels ciml/run.uuid=$RUN_UUID \
+        --nocolour \
+        ciml-run-training
+      # Start the training
+      tkn task start \
+        -i ciml=$GIT_RESOURCE \
+        -i experiments=$EXPERIMENTS_BUCKET_RESOURCE \
+        -i dataset=$DATASET_BUCKET_RESOURCE \
+        -o cimloutput=$OUTPUT_BUCKET_RESOURCE \
+        -p dataset=$dataset \
+        -p experiment=$experiment \
+        -s ciml-bot \
+        --showlog=false \
+        --labels ciml/run.uuid=$RUN_UUID \
+        --nocolour \
+        ciml-run-training
+    done
+  done
+}
+
+RUN_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+run_trainings

--- a/scripts/setup_datasets_tekton.sh
+++ b/scripts/setup_datasets_tekton.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Setup/refresh all datasets required for various experiments
+# It requires a k8s configuration in place.
+# The target cluster should have Tekton installed, the ciml-create-dataset Task
+# deployed, and the s3 secret in place to access the used buckets.
+# It assumes enough examples are cached already.
+# It assumes a git Tekton resource exists in the cluster.
+
+# Call with -p force=True to force recreating datasets
+
+DATA_PATH=${DATA_PATH:-s3://cimlrawdata}
+TARGET_DATA_PATH=${TARGET_DATA_PATH:-s3://cimlodsceu2019}
+SLICE=${SLICE:-":5000"}
+GIT_RESOURCE=${GIT_RESOURCE:-ciml-master}
+MAX_CONCURRENCY=${MAX_CONCURRENCY:-20}
+
+function _running_tasks() {
+  tkn tr list | egrep -c -v '(STATUS|Succeeded|Failed|ciml-run-training)'
+}
+
+function _wait_for_slot(){
+  running=$(_running_tasks)
+  while [[ $running -ge $MAX_CONCURRENCY ]]; do
+    echo "Waiting: $running tasks"
+    sleep 5
+    running=$(_running_tasks)
+  done
+}
+
+function create_datasets() {
+  for feature_regex in ${FEATURES}; do
+    for sampling in ${SAMPLINGS}; do
+      for class_label in ${CLASS_LABELS}; do
+        for build_name in ${BUILD_NAMES}; do
+          DATASET=$(echo $feature_regex | tr "|" "_" | sed -e "s/(//g" -e "s/)//g")-${sampling}-${class_label}
+          if [[ "$build_name" == "tempest-full-py3" ]]; then
+            DATASET="${DATASET}-py3"
+          fi
+          echo "=== Setting up dataset $DATASET"
+          # Wait for a slot, do not overload the cluster
+          _wait_for_slot
+          # Build the dataset
+          tkn task start ciml-create-dataset \
+            -i ciml=$GIT_RESOURCE \
+            -p dataset=$DATASET \
+            -p build-name=$build_name \
+            -p slicer=$SLICE \
+            -p sample-interval="$sampling" \
+            -p features-regex="$feature_regex" \
+            -p class-label=$class_label \
+            -p tdt-split="6 2 2" \
+            -p data-path=$DATA_PATH \
+            -p target-data-path=$TARGET_DATA_PATH \
+            --showlog=false \
+            --nocolour \
+            -p force=true $@
+        done
+      done
+    done
+  done
+}
+
+# Dataset by feature/label
+FEATURES="(usr|used|1m) (usr|1m) (usr|used) (usr) (used) (1m)"
+CLASS_LABELS="node_provider_all node_provider status"
+SAMPLINGS="1min"
+BUILD_NAMES="tempest-full tempest-full-py3"
+create_datasets
+
+# Dataset by sampling/label
+FEATURES="(usr|1m)"
+CLASS_LABELS="node_provider_all node_provider status"
+SAMPLINGS="1s 10s 30s 1min 5min 10min"
+BUILD_NAMES="tempest-full tempest-full-py3"
+create_datasets

--- a/scripts/setup_experiments.sh
+++ b/scripts/setup_experiments.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Setup/refresh all experiments
+# It requires CIML to be installed, and aws profile "ibmcloud"
+# to be defined.
+
+# Call with --force to force recreating datasets
+
+BATCH=128
+TARGET_DATA_PATH=${TARGET_DATA_PATH:-/git/github.com/mtreinish/ciml/data}
+S3_AUTH_URL=${S3_AUTH_URL:-https://s3.eu-geo.objectstorage.softlayer.net}
+S3_PROFILE=${S3_PROFILE:-ibmcloud}
+
+declare -A NETWORK_NAMES
+NETWORK_NAMES["10/10/10"]=dnn-3x10
+NETWORK_NAMES["100/100/100"]=dnn-3x100
+NETWORK_NAMES["100/100/100/100/100"]=dnn-5x100
+NETWORK_NAMES["500/500/500/500/500"]=dnn-5x500
+NETWORK_NAMES["100/100/100/100/100/100/100/100/100/100"]=dnn-10x100
+NETWORK_NAMES["1000/1000/1000"]=dnn-3x1000
+
+EPOCHS="100 500 1000 5000"
+
+for network in "${!NETWORK_NAMES[@]}"; do
+  for epochs in ${EPOCHS}; do
+    # Setup the experiment
+    EXPERIMENT=${NETWORK_NAMES[$network]}-${epochs}epochs-bs${BATCH}
+    echo "=== Setting up experiment $EXPERIMENT"
+    ciml-setup-experiment --experiment $EXPERIMENT \
+      --estimator tf.estimator.DNNClassifier \
+      --hidden-layers $network \
+      --steps $(( 2500 / BATCH * epochs )) \
+      --batch-size $BATCH \
+      --epochs ${epochs} \
+      --data-path $TARGET_DATA_PATH \
+      --s3-profile $S3_PROFILE \
+      --s3-url $S3_AUTH_URL $@
+  done
+done

--- a/tekton/run_trainings.yaml
+++ b/tekton/run_trainings.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: ciml-run-all-trainings
+spec:
+  volumes:
+    - name: ciml-data
+      configMap:
+        name: ciml-data
+  inputs:
+    params:
+    - name: git-resource
+      description: Name of the git resource to be used to the training tasks
+    - name: experiments-bucket-resource
+      description: Name of the bucket resources with experiments
+    - name: max-concurrency
+      description: Max concurrency for training tasks execution
+    - name: data-bucket
+      description: Name of the bucket that holds the datasets and experiments
+    - name: output-bucket
+      description: Name of the bucket where to write trained models to
+    resources:
+    - name: ciml
+      type: git
+  outputs:
+    resources:
+    - name: runlog
+      type: storage
+  steps:
+  - name: run-ciml-matrix
+    image: us.icr.io/ciml/tkn:v0.4
+    workingDir: $(inputs.resources.ciml.path)/scripts
+    env:
+    - name: GIT_RESOURCE
+      value: $(inputs.params.git-resource)
+    - name: EXPERIMENTS_BUCKET_RESOURCE
+      value: $(inputs.params.experiments-bucket-resource)
+    - name: MAX_CONCURRENCY
+      value: $(inputs.params.max-concurrency)
+    - name: DATA_BUCKET
+      value: $(inputs.params.data-bucket)
+    - name: OUTPUT_BUCKET
+      value: $(inputs.params.output-bucket)
+    - name: DATASETS
+      value: /data/datasets
+    - name: EXPERIMENTS
+      value: /data/experiments
+    - name: TRAINING_LOG
+      value: $(outputs.resources.runlog.path)/training_log.csv
+    volumeMounts:
+    - name: ciml-data
+      mountPath: /data
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      ./run_with_tekton.sh


### PR DESCRIPTION
Add a tekton task that can run trainings with experiments / datasets
defined in a configmap:

data:
  experiments:
    (...)
  datasets:
    (...)

The task uses the tkn client to trigger other tasks that run the
trainings. The trainings are executed with a max concurrentcy, and
the execution log is stored in a bucket.