### PR TITLE
Added connection timeout handling.

### DIFF
--- a/ciml/gather_results.py
+++ b/ciml/gather_results.py
@@ -207,7 +207,11 @@ def _get_dstat_file(artifact_link, run_uuid=None, sample_interval=None,
         if not artifact_link:
             break
         url = artifact_link + '/' + path
-        resp = requests.get(url)
+        try:
+            resp = requests.get(url, timeout=(3.05,15))
+        except requests.exceptions.ConnectionError:
+            print("Connection time out on {}".format(url))
+            continue
         if resp.status_code == 404:
             continue
         # Cache the file locally


### PR DESCRIPTION
When a log provider is not online anymore, fetching dstat files hits a
connection error which was not handled until now.
Added handling of the connection error to continue gathering logs.
Also added a connection timeout to speed up the failure.

Fixes issue #53.