### PR TITLE
Pin Tensorflow <2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ SQLAlchemy>=1.3.0 # MIT
 matplotlib>=2.1.2
 pandas>=0.20.1
 # tensorflow-gpu>=1.6.0 # Apache-2.0
-tensorflow>=1.6.0 # Apache-2.0
+tensorflow>=1.6.0,<2.0 # Apache-2.0
 PyMySQL>=0.8.0
 click
 flask>=0.12.2


### PR DESCRIPTION
On Tensorflow 2.x a lot of the API changed, and APIs that were
deprecated before have been moved to tf.compat or removed.

We might move the code to 2.x eventually, but for now pin the
version to 1.x to ensure things keep working.