### PR TITLE
Use tensorflow v1 compat API

### DIFF
--- a/ciml/dstat_data.py
+++ b/ciml/dstat_data.py
@@ -14,7 +14,8 @@
 
 import os
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_eager_execution()
 
 BATCH_SIZE = 1000
 

--- a/ciml/nn_trainer.py
+++ b/ciml/nn_trainer.py
@@ -28,7 +28,8 @@ import os
 
 import numpy as np
 import pandas as pd
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_eager_execution()
 
 from ciml import trainer
 

--- a/ciml/predict.py
+++ b/ciml/predict.py
@@ -18,7 +18,8 @@ import sys
 
 import click
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_eager_execution()
 
 from ciml import gather_results
 from ciml import listener

--- a/ciml/svm_trainer.py
+++ b/ciml/svm_trainer.py
@@ -16,9 +16,9 @@ import os
 
 import numpy as np
 import pandas as pd
-import tensorflow as tf
-
-tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
+import tensorflow.compat.v1 as tf
+tf.disable_eager_execution()
+tf.logging.set_verbosity(tf.logging.INFO)
 
 
 class SVMTrainer(object):

--- a/ciml/tf_trainer.py
+++ b/ciml/tf_trainer.py
@@ -16,9 +16,9 @@ import os
 
 import numpy as np
 import pandas as pd
-import tensorflow as tf
-
-tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
+import tensorflow.compat.v1 as tf
+tf.disable_eager_execution()
+tf.logging.set_verbosity(tf.logging.INFO)
 
 
 def get_feature_columns(labels):

--- a/ciml/trainer.py
+++ b/ciml/trainer.py
@@ -40,7 +40,8 @@ except ImportError:
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
 try:
-    import tensorflow as tf
+    import tensorflow.compat.v1 as tf
+    tf.disable_eager_execution()
     from tensorflow.python.training import adagrad
     from tensorflow.python.training import adam
     from tensorflow.python.training import ftrl

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ SQLAlchemy>=1.3.0 # MIT
 matplotlib>=2.1.2
 pandas>=0.20.1
 # tensorflow-gpu>=1.6.0 # Apache-2.0
-tensorflow>=1.6.0,<2.0 # Apache-2.0
+tensorflow>=1.6.0 # Apache-2.0
 PyMySQL>=0.8.0
 click
 flask>=0.12.2


### PR DESCRIPTION
Tensorflow provides a v1 compat API that can be used to run
v1 APIs with a TF2 installed. Switch all of our import to
those makes it possible to lift the tensorflow pin while
having CIML code still working.

There is no TF<2 for python 3.8, so this allows running
CIML on latest versions of python.